### PR TITLE
Update setup.py to change version of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-csv',
       py_modules=['tap_csv'],
       install_requires=[
           'singer-python>=0.2.1',
-          'backoff==1.3.2',
+          'backoff==1.8.0',
           'requests==2.12.4',
       ],
       entry_points='''


### PR DESCRIPTION
Updated backoff to version 1.8.0, as the singer api now requires this version.
Fixes Issue #2 